### PR TITLE
Hook refreshOptions instead of onFocus

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -48,20 +48,6 @@
 
       if ($target.hasClass('option-disabled')) {
         return;
-      } else if ($target.hasClass('create')) {
-        self.createItem();
-      } else {
-        value = $target.attr('data-value');
-        if (value) {
-          self.lastQuery = null;
-          self.setTextboxValue('');
-          self.addItem(value);
-          if (!self.settings.hideSelected && e.type && /mouse/.test(e.type)) {
-            self.setActiveOption(self.getOption(value));
-          }
-        }
-
-        self.blur();
       }
       return original.apply(this, arguments);
     };

--- a/plugin.js
+++ b/plugin.js
@@ -52,4 +52,35 @@
       return original.apply(this, arguments);
     };
   })();
+
+  self.disabledOptions = function() {
+    return options.disableOptions;
+  }
+
+  self.setDisabledOptions = function( values ) {
+    options.disableOptions = values
+  }
+
+  self.disableOptions = function( values ) {
+    if ( ! ( values instanceof Array ) ) {
+      values = [ values ]
+    }
+    values.forEach( function( val ) {
+      if ( options.disableOptions.indexOf( val ) == -1 ) {
+        options.disableOptions.push( val )
+      }
+    } );
+  }
+
+  self.enableOptions = function( values ) {
+    if ( ! ( values instanceof Array ) ) {
+      values = [ values ]
+    }
+    values.forEach( function( val ) {
+      var remove = options.disableOptions.indexOf( val );
+      if ( remove + 1 ) {
+        options.disableOptions.splice( remove, 1 );
+      }
+    } );
+  }
 });

--- a/plugin.js
+++ b/plugin.js
@@ -21,8 +21,8 @@
     'disableOptions': []
   }, options);
 
-  self.onFocus = (function() {
-    var original = self.onFocus;
+  self.refreshOptions = (function() {
+    var original = self.refreshOptions;
 
     return function() {
       original.apply(this, arguments);

--- a/plugin.less
+++ b/plugin.less
@@ -2,3 +2,6 @@
   color: #aaa;
   cursor: default;
 }
+.selectize-dropdown [data-selectable].option-disabled.active {
+  background-color: #eee;
+}


### PR DESCRIPTION
Selectize.js refreshes the DOM list of clickable options frequently,
such as after any option is selected, and when the user types to filter
the list of options.

The plugin needs to reapply the disabled class after every one of those
events, which it can do by running its extra code after every call to
refreshOptions.

Fixes mondorobot/selectize-disable-options#3.